### PR TITLE
remove travis gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ end
 
 group :development do
   # Use travis CI command
-  gem 'travis'
+  # gem 'travis'
 
   # JavaScript Interpreter
   gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
     arel (6.0.0)
-    backports (3.6.4)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -73,8 +71,6 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    ethon (0.7.3)
-      ffi (>= 1.3.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
     factory_girl (4.5.0)
@@ -82,19 +78,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faraday (0.9.1)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
     ffi (1.9.8)
     formatador (0.2.5)
-    gh (0.14.0)
-      addressable
-      backports
-      faraday (~> 0.8)
-      multi_json (~> 1.0)
-      net-http-persistent (>= 2.7)
-      net-http-pipeline
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     guard (2.12.6)
@@ -115,7 +100,6 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    highline (1.7.2)
     hirb (0.7.3)
     hirb-unicode (0.0.5)
       hirb (~> 0.5)
@@ -133,8 +117,6 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     kgio (2.9.3)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     libv8 (3.16.14.7)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -150,10 +132,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.7.0)
     multi_json (1.11.1)
-    multipart-post (2.0.0)
     nenv (0.2.0)
-    net-http-persistent (2.9.4)
-    net-http-pipeline (1.0.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     notiffany (0.0.6)
@@ -172,9 +151,6 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    pusher-client (0.6.2)
-      json
-      websocket (~> 1.0)
     rack (1.6.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -273,21 +249,8 @@ GEM
     tilt (1.4.1)
     timers (4.0.1)
       hitimes
-    travis (1.6.11)
-      addressable (~> 2.3)
-      backports
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9)
-      gh (~> 0.13)
-      highline (~> 1.6)
-      launchy (~> 2.1)
-      pry (~> 0.9)
-      pusher-client (~> 0.4)
-      typhoeus (~> 0.6, >= 0.6.8)
     turbolinks (2.5.3)
       coffee-rails
-    typhoeus (0.7.1)
-      ethon (>= 0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -303,7 +266,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    websocket (1.2.2)
 
 PLATFORMS
   ruby
@@ -340,8 +302,10 @@ DEPENDENCIES
   spring-commands-rspec
   sqlite3
   therubyracer
-  travis
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.4


### PR DESCRIPTION
pry-byebugのバージョンが低くなるので、gemからtravisを削除